### PR TITLE
feat: PR template to educate developers

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+<!-- PR Title Format (required): type(scope): short summary -->
+
+### 🚀 **Feature/Fix/Refactor**
+Briefly describe the primary purpose of this PR.
+
+### 📋 **Detailed Description**
+Provide a detailed explanation of your changes, including reasoning or related context.
+
+### 💥 **Breaking Changes**
+<!-- ⚠️ Only include if there are breaking changes ⚠️ -->
+- Clearly state any breaking changes.
+
+### ✅ **Related Issues**
+<!-- Reference issues this PR resolves -->
+- closes #issue_number
+
+### 📸 **Screenshots (if applicable)**
+<!-- Include screenshots if there are visual changes -->
+
+### 🔍 **Review Checklist**
+- [ ] My PR title follows the conventional commit format (`feat:`, `fix:`, etc.).
+- [ ] PR description clearly documents changes.
+- [ ] All related issues are linked.

--- a/Demo.Solution.Console/Program.cs
+++ b/Demo.Solution.Console/Program.cs
@@ -1,3 +1,5 @@
 ﻿// See https://aka.ms/new-console-template for more information
 Console.WriteLine("Hello, World!");
 Console.WriteLine("Feature 01"); 
+Console.WriteLine("Feature 02");
+Console.WriteLine("Feature 03 Breaking");


### PR DESCRIPTION
Added github PR template to generate default PR description with instructions
context.

Breaking Changes: Test

### ✅ **Related Issues**
- closes #1


### 🔍 **Review Checklist**
- [x ] My PR title follows the conventional commit format (`feat:`, `fix:`, etc.).
- [ x] PR description clearly documents changes.
- [ x] All related issues are linked.
